### PR TITLE
[Feature] Support for nested routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,22 @@ Route.group({ prefix: '/posts' }, () => {
 });
 ```
 
+### Nested routes
+
+Creates a nested route, building the `children` option for you.
+
+```js
+Route.nested('/posts', 'Posts', (Child) => {
+    Child.view('', 'PostIndex');             // '/posts'
+    Child.view('create', 'CreatePost');      // '/posts/create'
+    Child.view('edit', 'EditPost');          // '/posts/edit'
+    Child.view('/settings', 'PostSettings'); // '/settings'
+});
+```
+
 ### A note on slashes
 
-Options such as `path`, `redirect`, `alias`, and `prefix` are automatically formatted.
+Options such as `path`, `redirect`, `alias`, and `prefix` are automatically formatted, except `path` on nested routes.
 
 ```js
 '/'                // '/'

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Route.group({ prefix: '/posts' }, () => {
 
 ### Nested routes
 
-Creates a nested route, building the `children` option for you.
+Creates a nested route, appending all routes to the `children` option of the parent.
 
 ```js
 Route.nested('/posts', 'Posts', (Child) => {

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,8 +1,8 @@
 import { fixSlashes, multiguard } from './util';
 
 export default class Route {
-    constructor (path, key, value) {
-        this.config = { path: fixSlashes(path) };
+    constructor (path, key, value, root = true) {
+        this.config = { path: root ? fixSlashes(path) : path };
         this._set(key, value);
         this._guards = [];
     }

--- a/src/Routisan.js
+++ b/src/Routisan.js
@@ -1,7 +1,8 @@
 import Route from './Route';
 
 export default class Routisan {
-    constructor () {
+    constructor (root = true) {
+        this._root = root;
         this._resolver = (component) => component;
         this._routes = [];
         this._groupStack = {};
@@ -12,7 +13,7 @@ export default class Routisan {
     }
 
     _addRoute (path, key, value) {
-        const route = new Route(path, key, value);
+        const route = new Route(path, key, value, this._root);
 
         route.options(this._groupStack);
 
@@ -35,6 +36,18 @@ export default class Routisan {
         routes();
 
         this._groupStack = {};
+    }
+
+    nested (path, component, children) {
+        const route = this._addRoute(path, 'component', this._resolver(component));
+        const nestedRoutisan = new Routisan(false);
+        nestedRoutisan.setViewResolver(this._resolver);
+
+        children(nestedRoutisan);
+
+        route.options({
+            children: nestedRoutisan.all()
+        });
     }
 
     all () {


### PR DESCRIPTION
There was no way to create nested routes using the same fashion as root routes.

So I implemented a solution that is able to accept children routes in a fluent way:

```js
Route.nested('/posts', 'Posts', (Child) => {
    Child.view('', 'PostIndex');             // '/posts'
    Child.view('create', 'CreatePost');      // '/posts/create'
    Child.view('edit', 'EditPost');          // '/posts/edit'
    Child.view('/settings', 'PostSettings'); // '/settings'
});
```

## Description

All I do is reutilize the Routisan class, creating a temporary one in this case called "Child" passing it into the closure, then calling `all()` will get all the configurations of all "nested" routes and add them to the children property.

There is just one thing that I had to do that I don't really appreciate regarding `fixesSlashes`, children routes starting with "\dashboard" or "dashboard" aren't the same thing. Thus I add to make a configuration parameter to check if it is a root Routisan or not.

## Motivation and context

There was no way to define the children property fluently.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
- [ ] Add test coverage.
