### PR TITLE
Added support for route nesting more than 1 level deep

### DIFF
--- a/src/Routisan.js
+++ b/src/Routisan.js
@@ -19,7 +19,7 @@ export default class Routisan {
             route.options(this._groupStack.slice().reverse()[0]);
         }
 
-        (shared.root ? this._routes : shared.childRoutes).push(route);
+        (shared.isRoot() ? this._routes : shared.getState().childRoutes).push(route);
 
         return route;
     }

--- a/src/setters.js
+++ b/src/setters.js
@@ -13,15 +13,12 @@ export default {
         $this.config.beforeEnter = multiguard($this._guards);
     },
     children ($this, routes) {
-        shared.root = false;
+        shared.pushState();
 
         routes();
 
-        $this.config.children = shared.childRoutes.map((route) => route.config);
-
-        shared.childRoutes = [];
-
-        shared.root = true;
+        let sharedState = shared.popState();
+        $this.config.children = sharedState.childRoutes.map((route) => route.config);
     },
     prefix ($this, prefix) {
         $this.config.path = fixSlashes([prefix, $this.config.path]);

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,7 +1,25 @@
 const shared = {
     resolver: (component) => component,
-    childRoutes: [],
-    root: true
+    stack: [],
+
+    pushState: function () {
+        this.stack.push({
+            childRoutes: []
+        });
+    },
+    popState: function () {
+        return this.stack.pop();
+    },
+    /**
+     * getState
+     * @returns Object|undefined
+     */
+    getState: function () {
+        return this.stack[this.stack.length - 1];
+    },
+    isRoot: function () {
+        return !this.stack.length;
+    }
 };
 
 export default shared;

--- a/src/util.js
+++ b/src/util.js
@@ -9,7 +9,7 @@ export const fixSlashes = (path) => {
         path = getArray(path)
             .map((path) => path.replace(/^\/+|\/+$/g, ''))
             .join('/');
-        path = (shared.root ? `/${path}` : path);
+        path = (shared.isRoot() ? `/${path}` : path);
     }
 
     return path;


### PR DESCRIPTION
## Description

Adds a stack to the shared variable to retain child scope when adding child routes.

Closes #40 

## Motivation and context

From Vue Router docs:
```
As you can see the children option is just another Array of route configuration objects like routes itself.
Therefore, you can keep nesting views as much as you need.
```

Vue Router supports as much nesting as desired while this plugin currently fails without error when attempting to do so.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.

Do not send your pull request until all of the boxes are ticked.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
